### PR TITLE
Handle sub actions and local actions

### DIFF
--- a/internal/files/files.go
+++ b/internal/files/files.go
@@ -75,27 +75,28 @@ type SemverAction struct {
 	Full    string
 }
 
-var usesRegex = regexp.MustCompile(`(m?)uses: (.+)@(v[\d\.]+)`)
+var usesRegex = regexp.MustCompile(`uses: ([\w-]+/[\w-]+)(?:/[\w-]+)?@(v[\d.]+)`)
 
 // FindSemverActions finds all actions in a file that match patterns like:
 //
 //	uses: actions/checkout@v2
+//	uses: github/codeql-action/init@v3
 //
-// It returns the matches, or an error if there was a problem parsing the file.
-func FindSemverActions(fileContents string) ([]SemverAction, error) {
+// It returns the matches.
+func FindSemverActions(fileContents string) []SemverAction {
 	stringMatches := usesRegex.FindAllStringSubmatch(fileContents, -1)
 
 	var matches []SemverAction
 	for _, m := range stringMatches {
 		mm := SemverAction{
 			Full:    m[0],
-			Action:  m[2],
-			Version: m[3],
+			Action:  m[1],
+			Version: m[2],
 		}
 
 		matches = append(matches, mm)
 	}
-	return matches, nil
+	return matches
 }
 
 type HashGetter struct {
@@ -151,10 +152,7 @@ func UpdateFile(fileName string, status chan string, writer func(string, []byte,
 		return err
 	}
 
-	matches, err := FindSemverActions(fileContents)
-	if err != nil {
-		return err
-	}
+	matches := FindSemverActions(fileContents)
 	if len(matches) == 0 {
 		return nil
 	}

--- a/internal/files/files_test.go
+++ b/internal/files/files_test.go
@@ -1,0 +1,67 @@
+package files
+
+import (
+	"testing"
+)
+
+func Test_FindSemverActions(t *testing.T) {
+	for _, tt := range []struct {
+		name     string
+		input    string
+		expected []SemverAction
+	}{
+		{
+			name:     "no semver actions",
+			input:    "foo bar",
+			expected: nil,
+		},
+		{
+			name:     "one semver action",
+			input:    "uses: foo/bar@v1.2.3",
+			expected: []SemverAction{{Action: "foo/bar", Version: "v1.2.3", Full: "uses: foo/bar@v1.2.3"}},
+		},
+		{
+			name: "one semver action with content around",
+			input: `before content
+					uses: foo/bar@v1.2.3
+					after content`,
+			expected: []SemverAction{{Action: "foo/bar", Version: "v1.2.3", Full: "uses: foo/bar@v1.2.3"}},
+		},
+		{
+			name: "several semver actions",
+			input: `uses: foo/bar@v1.2.3
+ 				    uses: baz/qux@v4.5.6`,
+			expected: []SemverAction{
+				{Action: "foo/bar", Version: "v1.2.3", Full: "uses: foo/bar@v1.2.3"},
+				{Action: "baz/qux", Version: "v4.5.6", Full: "uses: baz/qux@v4.5.6"},
+			},
+		},
+		{
+			name:  "semver sub-action",
+			input: "uses: foo/bar/sub@v1.2.3",
+			expected: []SemverAction{
+				{Action: "foo/bar", Version: "v1.2.3", Full: "uses: foo/bar/sub@v1.2.3"},
+			},
+		},
+		{
+			name: "local action",
+			input: `uses: ./foo/bar
+					uses: baz/qux@v4.5.6`,
+			expected: []SemverAction{
+				{Action: "baz/qux", Version: "v4.5.6", Full: "uses: baz/qux@v4.5.6"},
+			},
+		},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			got := FindSemverActions(tt.input)
+			if len(got) != len(tt.expected) {
+				t.Fatalf("expected %d semver actions, got %d", len(tt.expected), len(got))
+			}
+			for i, v := range got {
+				if v != tt.expected[i] {
+					t.Fatalf("expected semver action %q, got %q", tt.expected[i], v)
+				}
+			}
+		})
+	}
+}


### PR DESCRIPTION
Actions can also be e.g.
```
      uses: github/codeql-action/init@v3
```
which means we need to find the hash of v3 for `github/codeql-action`, or
```
        uses: ./.github/my-action
```
which we need to ignore.